### PR TITLE
if '.' is passed in digits, from_base doesn't deal with '.' for decimal.

### DIFF
--- a/lib/Math/BaseCalc.pm
+++ b/lib/Math/BaseCalc.pm
@@ -27,7 +27,13 @@ sub digits {
       croak "Unrecognized digit set '$name'" unless exists $digitsets{$name};
       $self->{digits} = $digitsets{$name};
     }
-    $self->{has_dash} = grep { $_ eq '-' } @{$self->{digits}};
+    foreach my $digit (@{$self->{digits}}) {
+      if ($digit eq '-') {
+        $self->{has_dash} = 1;
+      } elsif ($digit eq '.') {
+        $self->{has_dot} = 1;
+      }
+    }
 
     $self->{trans} = {};
     # Build the translation table back to numbers
@@ -57,7 +63,7 @@ sub from_base {
 
   # Deal with stuff after the decimal point
   my $add_in = 0;
-  if ($str =~ s/\.(.+)//) {
+  if (!$self->{has_dot} && $str =~ s/\.(.+)//) {
     $add_in = $self->from_base(reverse $1)/$dignum**length($1);
   }
 

--- a/t/06_digit_dot.t
+++ b/t/06_digit_dot.t
@@ -1,0 +1,23 @@
+#! perl
+
+use strict;
+use warnings;
+use Test::More tests => 24;
+use_ok('Math::BaseCalc');
+
+my $calc = new Math::BaseCalc(digits=>[0,1]);
+isa_ok($calc, "Math::BaseCalc");
+
+
+my @calcs;
+push(@calcs, new Math::BaseCalc(digits => [ '0', '&' ]));
+push(@calcs, new Math::BaseCalc(digits => [ '0', '.' ]));
+
+for my $calcX ( @calcs ) {
+  for my $source (0..10) {
+    my $in_base_X  = $calcX->to_base( $source );
+    my $in_base_10 = $calcX->from_base( $in_base_X );
+	
+    is $in_base_10, $source, "from( to ( $source ) == $source ";
+  }
+}


### PR DESCRIPTION
Currently '.' can be passed as digits member and it works correctly in to_base.
But, in from_base, '.' is checked for decimal, so from_base returns decimal number.

This patch checks whether '.' exists in digits and if exists, set has_dot = 1.
In from_base, if has_dot is true, from_base doesn't deal with '.' for decimal.